### PR TITLE
Fix contradicting license information by choosing CC-BY 4.0

### DIFF
--- a/_includes/lesson_footer.html
+++ b/_includes/lesson_footer.html
@@ -26,7 +26,7 @@
 	Licensed under <a href="{{ site.cc_by_human }}">CC-BY 4.0</a> 2018–{{ 'now' | date: "%Y" }}
 	by <a href="{{ site.carpentries_site }}">The Carpentries</a>
 	{% endif %}-->
-	Licensed under <a href="{{ site.cc_by_human }}">CC-BY-SA 4.0</a> 2018–{{ 'now' | date: "%Y" }}
+	Licensed under <a href="{{ site.cc_by_human }}">CC-BY 4.0</a> 2018–{{ 'now' | date: "%Y" }}
 	by Jarno Rantaharju, Seyong Kim, Ed Bennett and <a href="{{ site.sa2c_site }}">Swansea Academy of Advanced Computing</a>
 		</div>
     <div class="col-md-6 help-links" align="right">

--- a/_includes/workshop_footer.html
+++ b/_includes/workshop_footer.html
@@ -17,7 +17,7 @@
 	<a href="{{ site.carpentries_site }}">The Carpentries</a>
   {% endif %}
         -->
-        Licensed under <a href="{{ site.cc_by_human }}">CC-BY-SA 4.0</a> 2018–{{ 'now' | date: "%Y" }}
+        Licensed under <a href="{{ site.cc_by_human }}">CC-BY 4.0</a> 2018–{{ 'now' | date: "%Y" }}
         by Jarno Rantaharju, Seyong Kim, Ed Bennett and and <a href="{{ site.sa2c_site }}">Swansea Academy of Advanced Computing</a>      
       </h4>
     </div>


### PR DESCRIPTION
Fix two contradicting licenses in the footer text and the license file. This will choose CC-BY 4.0, which is the more permissive of the two.

Review: Please confirm CC-BY 4.0 the license is OK